### PR TITLE
test to add missing csv

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,20 +8,25 @@ package:
 source:
   url: https://github.com/fair-ease/Source/archive/refs/tags/v{{ version }}.tar.gz
   sha256: b92fd32f80d6f894da9f130b792fddb3a6f0e1b56aca4d01baa653ed7bcbc1ff
+  paths:
+    - SOURCE/obs_postpro/probes_names.csv
+    - SOURCE/obs_postpro/url_countries.csv
 
 build:
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
-  noarch: python
+  number: 1
+  script: 
+    - {{ PYTHON }} -m pip install . -vv
+    - cp SOURCE/obs_postpro/probes_names.csv $PREFIX/lib/python$PY/site-packages/SOURCE/obs_postpro/
+    - cp SOURCE/obs_postpro/url_countries.csv $PREFIX/lib/python$PY/site-packages/SOURCE/obs_postpro/
 
 requirements:
   host:
-    - python >=3.8
+    - python
     - pip
     - poetry-core
 
   run:
-    - python >=3.8
+    - python
     - pykml
     - lxml
     - numpy


### PR DESCRIPTION
Missing csv files in the package related to this issue https://github.com/conda-forge/source-feedstock/issues/1 . I tried something but I am really not convinced and I am pretty sure it will not work. @conda-forge/help-python Do you have any clues ?

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
